### PR TITLE
refactor(btree): remove argument from btreeAllocateNode

### DIFF
--- a/include/btree.h
+++ b/include/btree.h
@@ -35,7 +35,7 @@ typedef struct
 #endif
 
 Btree btreeInit(int minDegree);
-Node *btreeAllocateNode(BlockId id);
+Node *btreeAllocateNode();
 ResultSet btreeSearch(Node *node, int k);
 void btreeSplitChild(Node *x, BlockId x_id, int index);
 void btreeInsertNonfull(Node *x, BlockId x_id, int value);

--- a/src/btree.c
+++ b/src/btree.c
@@ -19,7 +19,7 @@ Btree btreeInit(int minDegree)
 
   BlockId initalId = getNewBlockId();
   Btree BtreeStruct;
-  Node *rootT = btreeAllocateNode(initalId);
+  Node *rootT = btreeAllocateNode();
   rootT->leaf = true;
   ioWrite(rootT, initalId, MAXDEGREE);
   BtreeStruct.root = rootT;
@@ -27,7 +27,7 @@ Btree btreeInit(int minDegree)
   return BtreeStruct;
 }
 
-Node *btreeAllocateNode(BlockId id)
+Node *btreeAllocateNode()
 {
   int *data;
   BlockId *ids = malloc(MAXKEYS * sizeof(BlockId));
@@ -79,7 +79,7 @@ void btreeSplitChild(Node *x, BlockId x_id, int index)
 
   // new node going to id right of x
   BlockId z_id = getNewBlockId();
-  Node *z = btreeAllocateNode(z_id);
+  Node *z = btreeAllocateNode();
 
   // node on the left of x, currently full
   BlockId y_id = x->ids[index];
@@ -170,7 +170,7 @@ Btree btreeInsert(Btree T, int value)
   if (r->n == MAXDEGREE)
   {
     BlockId newRootId = getNewBlockId();
-    Node *s = btreeAllocateNode(newRootId);
+    Node *s = btreeAllocateNode();
     T.root = s;
     s->leaf = false;
     s->n = 0;

--- a/tests/test_btree.c
+++ b/tests/test_btree.c
@@ -30,7 +30,7 @@ Btree initializeFullBtree(int minDegree)
   for (int i = 0; i < maxDegree; i++)
   {
     cur_id = nodeRoot->ids[i];
-    iterNode = btreeAllocateNode(cur_id);
+    iterNode = btreeAllocateNode();
     iterNode->n = maxDegree;
     iterNode->n_ids = 0;
     iterNode->leaf = true;

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -17,7 +17,7 @@ Node **randomNodes(int nrNodes, int minDegree)
   Node *node;
   for (int i = 0; i < nrNodes; i++)
   {
-    node = btreeAllocateNode(i);
+    node = btreeAllocateNode();
     node->n = maxDegree;
     for (int j = 0; j < maxDegree; j++)
     {

--- a/tests/test_storage.c
+++ b/tests/test_storage.c
@@ -39,7 +39,7 @@ int testBtreeCreateNode(int minDegree)
 
   for (int i = 0; i < nr_nodes; i++)
   {
-    tmp_node = btreeAllocateNode(node->ids[i]);
+    tmp_node = btreeAllocateNode();
     for (int j = 0; j < maxDegree; j++)
     {
       tmp_node->data[j] = i * 10 + 100;
@@ -72,7 +72,7 @@ Btree initializeFullBtree(int minDegree)
   for (int i = 0; i < maxDegree; i++)
   {
     // printf("%i\n", nodeRoot->ids[i]);
-    iterNode = btreeAllocateNode(nodeRoot->ids[i]);
+    iterNode = btreeAllocateNode();
     iterNode->n = maxDegree;
     for (int j = 0; j < maxDegree; j++)
     {


### PR DESCRIPTION
the input arguemnt, blockid, is no longer used, since the blockid is incresed by the storage module